### PR TITLE
Update synthese.sql

### DIFF
--- a/synthese.sql
+++ b/synthese.sql
@@ -27,6 +27,7 @@ AS WITH source AS (
     o.uuid_observation AS unique_id_sinp,
     v.uuid_base_visit AS unique_id_sinp_grp,
     (SELECT id_source FROM source) AS id_source,
+    o.id_observation,
     o.id_observation AS entity_source_pk_value,
     v.id_dataset,
     ref_nomenclatures.get_id_nomenclature('METH_OBS'::character varying, '0'::character varying) AS id_nomenclature_obs_meth, 


### PR DESCRIPTION
Ajout de la colonne id_observation

car 
 :warning: Les colonnes `id_observation`, `unique_id_sinp` et `ids_observers` (tableau d'id_role) sont obligatoires pour assurer la synchronisation entre la vue et la synthese
(voir https://github.com/PnX-SI/gn_module_monitoring/blob/main/docs/synthese.md)

Sinon
Error in module monitoring, process_synthese.
                Function import_from_table with parameters(v_synthese_popreptile, id_observation, 8213) raises the following error :
                Undefined column : 'gn_monitoring.v_synthese_popreptile.id_observation'. 
 This column is mandatory to synchronize with synthese